### PR TITLE
[ci] Set runs-on to macos-10.15 and ubuntu-18.04 instead of latest

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -6,7 +6,7 @@ jobs:
 
   build-test:
     name: Build and test
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         include:
@@ -25,14 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-#      - name: Cache
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            ~/.cargo/registry
-#            ~/.cargo/git
-#            target
-#          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
         run: rustup default stable
       - name: Set profile
@@ -51,7 +43,7 @@ jobs:
 
   build-all:
     name: Build all targets
-    runs-on: macOS-latest
+    runs-on: ubuntu-18.04
     env:
       BUILD_TARGETS: aarch64,armv7,x86_64,i686
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "^0.11"
 
+# pin ring version to 0.16.15 because 0.16.16 breaks arm build
+ring = { version = "=0.16.15" }
+
 [patch.crates-io]
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin/", rev = "478e091" }
 miniscript = { git = "https://github.com/MagicalBitcoin/rust-miniscript", branch = "descriptor-public-key" }

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail -o xtrace
 
+# If ANDROID_NDK_HOME is not set then set it to github actions default
+[ -z "$ANDROID_NDK_HOME" ] && export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+
 # Update this line accordingly if you are not building *from* darwin-x86_64 or linux-x86_64
 export PATH=$PATH:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/`uname | tr '[:upper:]' '[:lower:]'`-x86_64/bin
 


### PR DESCRIPTION
Also in this PR: 
* pin `ring` version to 0.16.15 because 0.16.16 breaks the arm build
* I tested with and without caching and it was just as fast without so I removed it 