### PR TITLE
Remove hardcoded android.ndkversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,12 @@ If you haven't installed rust android targets first add those to your environmen
 rustup target add x86_64-apple-darwin x86_64-unknown-linux-gnu x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android
 ```
 
-Then make sure that you have an Android NDK installed (preferably the latest one), and that you have an `NDK_HOME` env variable set before you start building the library. Usually, if installed through the `sdkmanager`,
-your `NDK_HOME` will look more or less like this: `/home/user/Android/Sdk/ndk/<version>/`.
-
-Also make sure that you set the `NDK_HOME` env variable and add the prebuild binaries to your 
-`PATH` env variable, for example:  
+Then make sure that you have an Android NDK installed ([our Github CI is using 21.4.7075529](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md), 
+and that you have an `ANDROID_NDK_HOME` env variable set before you start building the library. Usually, if installed through the `sdkmanager`,
+your `ANDROID_NDK_HOME` will look more or less like this: `/home/<user>/Android/Sdk/ndk/<version>/`.
 
 ```
-export NDK_HOME=/home/<user>/Android/Sdk/ndk/22.1.7171670
-export PATH=$PATH:$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
+export ANDROID_NDK_HOME=/home/<user>/Android/Sdk/ndk/<NDK version, ie. 21.4.7075529>
 ```
 
 Build android library in `.aar` format with:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ containing one or more of the following items:
 
 The output aar library is available at `./library/build/outputs/aar`.
 
-Then you can run the tests with:
+To run the tests first launch a local android emulator from the Android Studio IDE or via the command line. 
+If starting from the command line you will also need to set the `ANDROID_SDK_ROOT` env variable.
+
+```
+export ANDROID_SDK_ROOT=</home/<user>/Android/Sdk or where ever your Sdk is installed>
+```
+
+Then start the connected unit tests with:
 ```sh
 ./gradlew connectedDebugAndroidTest
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bdk-jni
 
-![CI](https://github.com/bitcoindevkit/bdk-jni/workflows/CI/badge.svg)
+<a href="https://github.com/bitcoindevkit/bdk-jni/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk-jni/workflows/CI/badge.svg"></a>
 
 Install Open JDK 14 or later if not already installed and make sure your `JAVA_HOME` env variable is
 set and `java --version` is found and displays the the correct version.

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'maven-publish'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
-    ndkVersion "21.4.7075529"
 
     defaultConfig {
         minSdkVersion 21

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ use electrum_client::Client;
 use bdk::keys::bip39::{Language, Mnemonic, MnemonicType};
 use bdk::keys::{DerivableKey, ExtendedKey, GeneratableKey, GeneratedKey};
 use bdk::miniscript::miniscript;
+use bdk::wallet::AddressIndex::New;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::{Address, Network, OutPoint, Transaction};
-use bdk::wallet::AddressIndex::New;
 
 #[derive(Debug, Deserialize)]
 struct KotlinPair<F: std::fmt::Debug, S: std::fmt::Debug> {


### PR DESCRIPTION
### Description

Remove hardcoded android.ndkversion and update `README.md` to use `ANDROID_NDK_HOME` env variable. Also fix cargo fmt error and add link to CI badge in `README.md`.

### Notes to the reviewers

Even though using the `ANDROID_NDK_HOME` env variable throws a warning that it is being deprecated I think it's still better for now to use it so it's easier to test different NDK versions locally and stay in sync with latest Github actions `ANDROID_NDK_HOME` version.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-jni/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
