### PR TITLE
Release/0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return Transaction details data list from list_transactions
 - Add android unit tests
 - Add android tests
-- Update `bdk` to rev `0.4`
+- Update `bdk` to rev `0.7`
 - Add multi-thread coroutine test, fix Lib.call() request string handling
 - Add create and restore extended key APIs
+
+#### Fixed
+- Fix crashes on errors
 
 [unreleased]: https://github.com/bitcoindevkit/bdk-jni/compare/d08725cc...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.2.0]
+
 ### Project
 #### Added
 - Add LICENSE
@@ -36,4 +38,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - Fix crashes on errors
 
-[unreleased]: https://github.com/bitcoindevkit/bdk-jni/compare/d08725cc...HEAD
+[unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/bitcoindevkit/bdk-jni/compare/d08725cc...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ android_logger = "0.8"
 crate-type = ["dylib"]
 
 [dependencies]
-bdk = { version = "^0.6", features = ["all-keys"] }
+bdk = { version = "^0.7", features = ["all-keys"] }
 log = "0.4.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-jni"
-version = "0.2.0"
+version = "0.2.1-dev"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 edition = "2018"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -45,7 +45,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'org.bitcoindevkit.bdkjni'
                 artifactId = 'bdk-jni'
-                version = '0.2.0'
+                version = '0.2.1-dev'
             }
             // Creates a Maven publication called “debug”.
             debug(MavenPublication) {
@@ -54,7 +54,7 @@ afterEvaluate {
 
                 groupId = 'org.bitcoindevkit.bdkjni'
                 artifactId = 'bdk-jni-debug'
-                version = '0.2.0'
+                version = '0.2.1-dev'
             }
         }
     }


### PR DESCRIPTION
### Description

* Update bdk version to 0.7.0
* tag bdk-jni release 0.2.0
* bump bdk-jni release to 0.2.1-dev

### Notes to the reviewers

The primary change in this new 0.2.0 release is #30. 

Also fixed clippy errors which required renaming some enums to use camel case.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-jni/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
