### PR TITLE
feat: library release github action

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -3,7 +3,7 @@ name: Library Releaser
 on:
   push:
     tags:
-      - "*"
+      - 'v*.*.*'
 
 jobs:
   releaser:
@@ -22,23 +22,10 @@ jobs:
         run: rustup target add x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi
       - name: Build
         run: ./gradlew build
-      - name: release
-        uses: actions/create-release@v1
-        id: create_release
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          draft: false
-          prerelease: false
-          release_name: bdk-jni-${{ github.ref }}
-          tag_name: ${{ github.ref }}
-          body_path: CHANGELOG.md
+          files: library/build/outputs/aar/library-release.aar
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      - name: upload linux artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: library/build/outputs/aar/library-release.aar
-          asset_name: library-release.aar
-          asset_content_type: application/gzip
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,44 @@
+name: Library Releaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  releaser:
+    name: build_releaser
+    runs-on: ubuntu-latest
+    env:
+      BUILD_TARGETS: aarch64,armv7,x86_64,i686
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set default toolchain
+        run: rustup default stable
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add targets
+        run: rustup target add x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi
+      - name: Build
+        run: ./gradlew build
+      - name: release
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          release_name: bdk-jni-${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - name: upload linux artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: library/build/outputs/aar/library-release.aar
+          asset_name: library-release.aar
+          asset_content_type: application/gzip


### PR DESCRIPTION
Signed-off-by: DarthBenro008 <hkpdev008@gmail.com>

### Description

This PR partially addresses #33 

What does this GitHub action do?

Whenever you push a tag to GitHub. `i.e: git tag v2.0 master && git push origin master` 

- This GitHub action will take the code from master branch and create a build
- It will create a release with that tag name
- It will also include CHANGELOG.md in the release body
- It will upload the generated library as an release file for people to download!


The result will look similar to this:

![image](https://user-images.githubusercontent.com/31009634/125495430-ad8fb2ae-4f64-4abb-bd50-71ac8fcc364f.png)


### Notes to the reviewers

**NOTE: In order for this GitHub action to work, the repo owner(s) must create a secret named "RELEASE_TOKEN" and fill it with a GitHub token with required permission to create a release, this is an very important and crucial step for this action to work!**

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-jni/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

