### PR TITLE
Upgrade BDK version, add new electrum params and get_last_unused_address()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade bdk to v0.11.0
+- Add new `WalletConstructor` parameters: `electrum_proxy`, `electrum_retry`, `electrum_timeout`, and `electrum_stop_gap`
+
 ## [v0.2.0]
 
 ### Project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade bdk to v0.11.0
 - Add new `WalletConstructor` parameters: `electrum_proxy`, `electrum_retry`, `electrum_timeout`, and `electrum_stop_gap`
+- Add new `Lib.get_last_unused_address()` function
 
 ## [v0.2.0]
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,9 +73,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'com.github.tony19:logback-android:2.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'com.github.tony19:logback-android:2.0.0'
     androidTestImplementation(project(':test-fixtures'))
 }

--- a/jvm/src/main/java/org/bitcoindevkit/bdkjni/Lib.kt
+++ b/jvm/src/main/java/org/bitcoindevkit/bdkjni/Lib.kt
@@ -59,6 +59,19 @@ class Lib {
         return json.asText()
     }
 
+    fun get_last_unused_address(wallet: WalletPtr): String {
+        val node = JsonNodeFactory.instance.objectNode()
+        node.set("wallet", mapper.valueToTree<JsonNode>(wallet))
+        val req = JsonRpc("get_last_unused_address", node)
+        val reqString = mapper.writeValueAsString(req)
+        val resString = call(reqString)
+        val json: JsonNode = mapper.readValue(resString)
+        if (json.has("error")) {
+            throw Exception(json.get("error").asText())
+        }
+        return json.asText()
+    }
+
     fun sync(wallet: WalletPtr, max_address: Int?=null) {
         val node = JsonNodeFactory.instance.objectNode()
         node.set("wallet", mapper.valueToTree<JsonNode>(wallet))

--- a/jvm/src/main/java/org/bitcoindevkit/bdkjni/Types.kt
+++ b/jvm/src/main/java/org/bitcoindevkit/bdkjni/Types.kt
@@ -14,8 +14,19 @@ data class WalletConstructor(
     var descriptor: String,
     var change_descriptor: String?,
 
+    /**
+     * URL of the Electrum server (such as ElectrumX, Esplora, BWT) may start with `ssl://` or `tcp://` and include a port
+     * eg. `ssl://electrum.blockstream.info:60002`
+     */
     var electrum_url: String,
-    var electrum_proxy: String?
+    /** URL of the socks5 proxy server or a Tor service, null means no proxy */
+    var electrum_proxy: String?,
+    /** Request retry count */
+    var electrum_retry: Int,
+    /** Request timeout (seconds), null means no timeout */
+    var electrum_timeout: Int?,
+    /** Stop searching addresses for transactions after finding an unused gap of this length */
+    var electrum_stop_gap: Long,
 )
 
 data class TxOut(

--- a/native-libs/Cargo.toml
+++ b/native-libs/Cargo.toml
@@ -12,7 +12,7 @@ android_logger = "0.8"
 crate-type = ["dylib"]
 
 [dependencies]
-bdk = { version = "^0.10", features = ["all-keys"] }
+bdk = { version = "^0.11", features = ["all-keys"] }
 jni = { version = "0.15", default-features = false }
 log = "0.4.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/test-fixtures/src/main/java/org/bitcoindevkit/bdkjni/LibTest.kt
+++ b/test-fixtures/src/main/java/org/bitcoindevkit/bdkjni/LibTest.kt
@@ -62,9 +62,29 @@ abstract class LibTest {
         val dir = getDataDir()
         val wallet = constructor(dir)
         try {
-            val address = Lib().get_new_address(wallet)
-            assertFalse(address.isEmpty())
-            log.debug("newAddress: $address")
+            val newAddress1 = Lib().get_new_address(wallet)
+            assertFalse(newAddress1.isEmpty())
+            log.debug("newAddress1: $newAddress1")
+            val newAddress2 = Lib().get_new_address(wallet)
+            log.debug("newAddress2: $newAddress2")
+            assertNotEquals(newAddress1, newAddress2)
+        } finally {
+            Lib().destructor(wallet)
+            cleanupDataDir(dir)
+        }
+    }
+
+    @Test
+    fun lastUnusedAddress() {
+        val dir = getDataDir()
+        val wallet = constructor(dir)
+        try {
+            val unusedAddress1 = Lib().get_last_unused_address(wallet)
+            assertFalse(unusedAddress1.isEmpty())
+            log.debug("unusedAddress1: $unusedAddress1")
+            val unusedAddress2 = Lib().get_last_unused_address(wallet)
+            log.debug("unusedAddress2: $unusedAddress2")
+            assertEquals(unusedAddress1, unusedAddress2)            
         } finally {
             Lib().destructor(wallet)
             cleanupDataDir(dir)

--- a/test-fixtures/src/main/java/org/bitcoindevkit/bdkjni/LibTest.kt
+++ b/test-fixtures/src/main/java/org/bitcoindevkit/bdkjni/LibTest.kt
@@ -47,7 +47,10 @@ abstract class LibTest {
                 descriptor,
                 null,
                 electrum,
-                null
+                null,
+                5,
+                null,
+                100,
             )
         )
         Lib().sync(wallet)


### PR DESCRIPTION
### Description

- Upgrade bdk to v0.11.0
- Add new `WalletConstructor` parameters: `electrum_proxy`, `electrum_retry`, `electrum_timeout`, and `electrum_stop_gap`, 
closes #41 
- Add new `Lib.get_last_unused_address()` function, 
closes #44 


### Notes to the reviewers

I've only run the automated tests, I haven't tested these changes with an actual android app.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-jni/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
